### PR TITLE
Add lang attribute to HTML document

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <title><%= content_for(:title) || "Group App" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">


### PR DESCRIPTION
Accessibility Improvement

Added a valid lang="en" attribute to the HTML document to improve screen reader pronunciation and WCAG accessibility compliance.

Fixes accessibility issue identified in automated accessibility report.